### PR TITLE
Always direct backup even when volume is in-use

### DIFF
--- a/cinderback.py
+++ b/cinderback.py
@@ -555,51 +555,18 @@ class BackupService(object):
         # Use encoded original volume info as description
         description = BackupInfo(volume)
 
-        if volume.status == 'in-use':
-            _LI('Volume online so this is a multi-step process')
-
-            # Force snapshot since volume it's in-use
-            snapshot = self._create_and_wait(
-                'Creating snapshot', client.volume_snapshots,
-                arguments=dict(
-                    volume_id=volume.id, force=True, name='tmp ' + name,
-                    description='Temporary snapshot for backup',
-                    metadata=volume.metadata))
-
-            # Create temporary volume from snapshot
-            tmp_vol = self._create_and_wait(
-                'Creating temp volume from snapshot', client.volumes,
-                arguments=dict(
-                    size=snapshot.size, snapshot_id=snapshot.id,
-                    name='tmp '+name,
-                    description='Temporary volume for backup',
-                    metadata=volume.metadata), resources=(snapshot,))
-
-            # Backup temporary volume
+        if volume.status in ['available', 'in-use']:
             backup = self._create_and_wait(
-                'Doing the actual backup', client.backups,
-                arguments=dict(
-                    volume_id=tmp_vol.id, name=name, container=None,
-                    description=str(description)),
-                resources=(snapshot, tmp_vol))
-
-            # Cleanup temporary resources
-            _LI('Deleting temporary volume and snapshot')
-            tmp_vol.delete()
-            snapshot.delete()
-
-        elif volume.status == 'available':
-            backup = self._create_and_wait(
-                'Creating direct backup', client.backups,
+                'Creating backup', client.backups,
                 arguments=dict(
                     volume_id=volume.id, name=name, container=None,
-                    description=str(description)))
+                    description=str(description), force=True))
+            return backup
 
         else:
             _LE("We don't backup volume because status is %s", volume.status)
             raise UnexpectedStatus(what=volume)
 
-        return backup
 
     def _is_auto_backup(self, backup):
         """Check if a backup was created by us."""


### PR DESCRIPTION
Since OpenStack Liberty, Cinder has [supported non-disruptive volumes of in-use volumes](https://gorka.eguileor.com/in-use-volume-backups-in-cinder/). We don't need to take a separate snapshot, create a temporary volume from that snapshot, and back that up anymore. This change passes the `force=True` flag when the volume is created, so that Cinder will always back up the volume even if it is in use.

This will also make Ceph incremental backups work again (because subsequent backups will be backing up the same volume rather than different volumes).

~(Note that right now this PR also contains [these](https://github.com/Akrog/cinderback/pull/5/files) commits; will rebase against master before removing WIP in title.)~